### PR TITLE
Replace attachment error with warning

### DIFF
--- a/src/soap.rs
+++ b/src/soap.rs
@@ -447,8 +447,7 @@ fn parse_buglog(item: &xmltree::Element) -> Result<BugLog, String> {
                 }
                 "attachments" => {
                     if !e.children.is_empty() {
-                        // TODO: Implement attachment support
-                        return Err("Attachments not supported yet".to_string());
+                        log::warn!("Attachments found but not supported (apparently not implemented on the server side)");
                     }
                 }
                 n => {


### PR DESCRIPTION
Change attachment handling from returning an error to logging a warning, since attachments are apparently not implemented on the server side.